### PR TITLE
Fix missing string for 2x Flawed Amethyst

### DIFF
--- a/Eastern_Sun_Resurrected.mpq/data/local/lng/strings/item-runes.json
+++ b/Eastern_Sun_Resurrected.mpq/data/local/lng/strings/item-runes.json
@@ -18596,5 +18596,22 @@
     "ptBR": "Cura",
     "ruRU": "Лечение",
     "zhCN": "治疗"
+  },
+  {
+    "id": 90003,
+    "Key": "Runeword80",
+    "enUS": "Mighty",
+    "zhTW": "強力",
+    "deDE": "Mächtig",
+    "esES": "Poderoso",
+    "frFR": "Puissant",
+    "itIT": "Possente",
+    "koKR": "강력한",
+    "plPL": "Potężny",
+    "esMX": "Poderoso",
+    "jaJP": "強力な",
+    "ptBR": "Poderoso",
+    "ruRU": "Могущественный",
+    "zhCN": "强大"
   }
 ]


### PR DESCRIPTION
String mapping was missing, was getting missing string for GFV GFV recipe.

- Added string mapping for Runeword80
- Put it in the back of the array with the next ID
- Copied all of the other details from the other Mighty entries

Note: did not test this in any way