### PR TITLE
Fix v3.3.0.2 link in docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -76,7 +76,7 @@ Arial;color:#C8B478;mso-ansi-language:EN-US" lang="EN-US">Eastern Sun Resurrecte
                                                             Sun Resurrected 3.3.02 -
                                                             23/04/2025</span></b></div>
                                                 <div style="text-align: center;"><br><a
-                                                        href="https://docs.google.com/document/d/15fvZ8ULTdIrEWXNGMfAQDG4sN23YlVh7O4LchIsEBqM">Bug fixes, crossbow changes</a><br><br><br></div>
+                                                        href="https://docs.google.com/document/d/1K9BpamtfVQspxC13eqqoovoKFz1aIEuCPK1HXQKNcdw">Bug fixes, crossbow changes</a><br><br><br></div>
                                                 <div style="text-align: center;"><b><span style="color: #c8b478;">Eastern
                                                             Sun Resurrected 3.3.01 -
                                                             22/04/2025</span></b></div>


### PR DESCRIPTION
Fix broken link, it was pointing to v3.3.0.1 docs instead.